### PR TITLE
Add a pipeline for output into individual JSON files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,7 @@ data/
 
 *.pyc
 __pycache__/
+
 *.log
+*.json
+*.csv

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # strava-timeseries-archive
-> Download all the time series data from your Strava account into a single CSV file
+> Download all the time series data in your Strava account history
+> - into a single CSV file
+> - into JSON files, one per activity
 
 This app solves a number of problems you'd encounter when downloading personal
 activity data in bulk from the Strava API.
@@ -68,10 +70,18 @@ pip install -r downloader/requirements.txt
 
 ### Step 2.1: Adjust spider settings
 
-Modify `downloader/project/settings.py`: adjust `DOWNLOAD_DELAY` and 
-`AUTOTHROTTLE_TARGET_CONCURRENCY` to suit your app's rate limit situation. 
-At the time of this writing (November 8, 2023) the default limits for new
-apps are 100 requests per 15 minute interval and 1000 requests per day.^[https://communityhub.strava.com/t5/developer-knowledge-base/rate-limits/ta-p/4289]
+Modify `downloader/scrapy_project/project/settings.py` to meet your needs.
+
+Decide whether you'd like to download your time series data into a single
+large CSV file, many small JSON files, or both. Designate your choice by
+commenting/uncommenting each pipeline within the `ITEM_PIPELINES` setting.
+Be sure to set the desired output directory for each activated pipeline
+using the settings `CSV_OUTPUT_DIR` and/or `JSON_OUTPUT_DIR`.
+
+Adjust `DOWNLOAD_DELAY` and `AUTOTHROTTLE_TARGET_CONCURRENCY` to suit your
+app's rate limit situation. At the time of this writing (November 8, 2023)
+the default limits for new apps are 100 requests per 15 minute interval and
+1000 requests per day.^[https://communityhub.strava.com/t5/developer-knowledge-base/rate-limits/ta-p/4289]
 
 ### Step 2.2: Run the spider
 

--- a/downloader/scrapy_project/project/adapters.py
+++ b/downloader/scrapy_project/project/adapters.py
@@ -9,6 +9,8 @@ import dddhns.domain.language as lang
 from dddhns.repository import AbstractExportRepository
 from dddhns.translation import AbstractActivityDataTranslator
 
+from .items import StreamSet
+
 
 class MultiActivityDataCSVFileExportRepository(AbstractExportRepository):
     def __init__(self, directory):
@@ -56,17 +58,17 @@ class MultiActivityDataCSVFileExportRepository(AbstractExportRepository):
 
 
 class StravaAPIScrapyItemActivityDataTranslator(AbstractActivityDataTranslator):
-    def to_activity_data(self, item) -> ActivityData:
-        id = item['id']
-        type = item['type']
-        timeseries = self._to_timeseries(item)
+    def to_activity_data(self, stream_set: StreamSet) -> ActivityData:
+        id = stream_set['activity_id']
+        type = stream_set['type']
+        timeseries = self._to_timeseries(stream_set)
         return ActivityData(id, type, timeseries)
 
-    def _to_timeseries(self, item) -> Timeseries:
+    def _to_timeseries(self, stream_set: StreamSet) -> Timeseries:
         dataframe = pd.DataFrame({stream['type']: stream['data']
-                                  for stream in item['streams']})
+                                  for stream in stream_set['streams']})
 
-        start_dt_utc = datetime.datetime.strptime(item['start_date'], 
+        start_dt_utc = datetime.datetime.strptime(stream_set['start_date'], 
                                                   '%Y-%m-%dT%H:%M:%SZ')
         dataframe[lang.TIMESTAMP] = start_dt_utc   \
             + pd.to_timedelta(dataframe[lang.TIME], unit='s')

--- a/downloader/scrapy_project/project/items.py
+++ b/downloader/scrapy_project/project/items.py
@@ -1,0 +1,18 @@
+from scrapy.item import Field, Item
+
+
+class StravaAPIResourceItem(Item):
+    # athlete_id = Field()
+    activity_id = Field()
+    data = Field()
+
+
+class SummaryActivity(StravaAPIResourceItem):
+    # At the moment, I just want to save all fields without validating them.
+    pass
+
+
+class StreamSet(StravaAPIResourceItem):
+    # the actual JSON response from Strava API is in `data`
+    start_date = Field()
+    type = Field()

--- a/downloader/scrapy_project/project/pipelines.py
+++ b/downloader/scrapy_project/project/pipelines.py
@@ -1,7 +1,12 @@
+import json
+import os
+
 from .adapters import (
     MultiActivityDataCSVFileExportRepository,
     StravaAPIScrapyItemActivityDataTranslator,
 )
+from .items import SummaryActivity, StreamSet
+
 
 class MultiActivityDataCSVPipeline:
     def __init__(self, directory):
@@ -13,8 +18,37 @@ class MultiActivityDataCSVPipeline:
         return cls(repo_path)
     
     def process_item(self, item, spider):
-        translator = StravaAPIScrapyItemActivityDataTranslator()
-        activity_data = translator.to_activity_data(item)
-        self.repository.save(activity_data)
+        if isinstance(item, StreamSet):
+            translator = StravaAPIScrapyItemActivityDataTranslator()
+            activity_data = translator.to_activity_data(item)
+            self.repository.save(activity_data)
+        
+        return item
+
+
+class JSONDocumentPipeline:
+    def __init__(self, directory):
+        self.directory = directory
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        repo_path = crawler.settings.get('JSON_OUTPUT_DIR')
+        return cls(repo_path)
+    
+    def process_item(self, item, spider):
+        if isinstance(item, (SummaryActivity, StreamSet)):
+            activity_directory = os.path.join(self.directory, 
+                                              'activities/',
+                                              str(item.get('activity_id')))
+            fname = 'summary.json' if isinstance(item, SummaryActivity)  \
+                    else 'streams.json'
+            file_path = os.path.join(activity_directory, fname)
+
+            resource_data = item.get('data')
+
+            os.makedirs(activity_directory, exist_ok=True)
+
+            with open(file_path, 'w') as f:
+                json.dump(resource_data, f)
         
         return item

--- a/downloader/scrapy_project/project/settings.py
+++ b/downloader/scrapy_project/project/settings.py
@@ -6,19 +6,21 @@ NEWSPIDER_MODULE = "project.spiders"
 ROBOTSTXT_OBEY = False
 
 ITEM_PIPELINES = {
-    "project.pipelines.MultiActivityDataCSVPipeline": 333
+    "project.pipelines.MultiActivityDataCSVPipeline": 333,
+    "project.pipelines.JSONDocumentPipeline": 343,
 }
 
-# where should MultiActivityDataCSVPipeline save the output CSV file?
-CSV_OUTPUT_DIR = "."  
+CSV_OUTPUT_DIR = "."  # used with MultiActivityDataCSVPipeline
 
-# DOWNLOAD_DELAY = 0       # dft 0?
-# CONCURRENT_ITEMS = 10    # dft 100
-# CONCURRENT_REQUESTS = 5  # dft 16
+JSON_OUTPUT_DIR = "." # used with JSONDocumentPipeline
 
-AUTOTHROTTLE_ENABLED = True             # dft False
-AUTOTHROTTLE_TARGET_CONCURRENCY = 0.67  # dft 1.0
-AUTOTHROTTLE_MAX_DELAY = 60             # dft 60
+# DOWNLOAD_DELAY = 0       # default 0?
+# CONCURRENT_ITEMS = 10    # default 100
+# CONCURRENT_REQUESTS = 5  # default 16
+
+AUTOTHROTTLE_ENABLED = True             # default False
+AUTOTHROTTLE_TARGET_CONCURRENCY = 0.67  # default 1.0
+AUTOTHROTTLE_MAX_DELAY = 60             # default 60
 
 # Set settings whose default value is deprecated to a future-proof value
 REQUEST_FINGERPRINTER_IMPLEMENTATION = "2.7"

--- a/downloader/scrapy_project/project/spiders/activities.py
+++ b/downloader/scrapy_project/project/spiders/activities.py
@@ -4,15 +4,17 @@ import scrapy
 import scrapy.exceptions
 import scrapy.http
 
+from ..items import SummaryActivity, StreamSet
+
 
 class AthleteActivitiesStravaAPISpider(scrapy.Spider):
     name = 'activities'
     url_base = 'http://localhost:5000/proxy'
 
     def start_requests(self):
-        yield self._create_activities_list_request(page=1)
+        yield self.create_athlete_activities_request(page=1)
     
-    def parse_summary_list_page(self, response):
+    def parse_athlete_activities_page(self, response):
         data = response.json()
 
         # crude format validation
@@ -24,41 +26,49 @@ class AthleteActivitiesStravaAPISpider(scrapy.Spider):
         if len(data) == 200:
             url_params = parse_qs(urlparse(response.request.url).query)
             this_pg = int(url_params.get('page', [1])[0])
-            yield self._create_activities_list_request(page=this_pg + 1)
+            yield self.create_athlete_activities_request(page=this_pg + 1)
 
         for activity_summary in data:
-            yield self._create_activity_streams_request(activity_summary)
+            summary_activity = SummaryActivity({
+                'activity_id': activity_summary['id'],
+                'data': activity_summary,
+            })
+
+            yield summary_activity
+
+            yield self.create_activity_streams_request(summary_activity)
 
     def parse_activity_streams(self, response):
         streams_data = response.json()
-        
+
         if not isinstance(streams_data, list) or not len(streams_data):
             raise scrapy.exceptions.DropItem
-        
-        yield {
-            'id': response.meta['id'],
+
+        yield StreamSet({
+            'activity_id': response.meta['activity_id'],
             'start_date': response.meta['start_date'],
             'type': response.meta['type'],
-            'streams': streams_data,
-        }
+            'data': streams_data,
+        })
 
-    def _create_activities_list_request(self, page=1):
+    def create_athlete_activities_request(self, page=1):
         return scrapy.http.Request(
             f'{self.url_base}/athlete/activities?per_page=200&page={page}',
-            callback=self.parse_summary_list_page, dont_filter=True)
-    
-    def _create_activity_streams_request(self, activity_summary):
+            callback=self.parse_athlete_activities_page, dont_filter=True)
+
+    def create_activity_streams_request(self, summary_activity: SummaryActivity):
         all_available_keys = ('time,cadence,distance,altitude,velocity_smooth,'
                               'heartrate,latlng,watts,temp,moving,grade_smooth')
 
-        streams_resource_url = (
-            f'{self.url_base}/activities/{activity_summary["id"]}/streams'
-            f'?keys={all_available_keys}')
+        activity_id = summary_activity.get('activity_id')
         
+        resource_url = (f'{self.url_base}/activities/{activity_id}'
+                        f'/streams?keys={all_available_keys}')
+
         return scrapy.http.Request(
-            streams_resource_url,
-            meta={'id': activity_summary['id'],
-                  'start_date': activity_summary['start_date'],
-                  'type': activity_summary['type']},
+            resource_url,
+            meta={'activity_id': activity_id,
+                  'start_date': summary_activity.get('start_date'),
+                  'type': summary_activity.get('type')},
             callback=self.parse_activity_streams
         )


### PR DESCRIPTION
An alternate path to MultiActivityCSVPipeline. Instead of one big file, one small file per activity arranged in a sensible directory structure.

- Add pipelines.JSONDocumentPipeline, somewhat analogous to
  MultiActivityDataCSVPipeline
- Modify activities spider so it yields an item for each activity_summary
  in the page (in addition to the activity streams request that was
  already being yielded)
- create items.py for ActivitySummary and StreamSet, which correspond
  to the 2 types of resources I am grabbing from the Strava API server
- In MultiActivityDataCSVPipeline, add an item type check and only save
  stream data
- settings.py: Add JSONDocumentPipeline options
- Update README